### PR TITLE
Fix getBlob, getDataURL when image isn't dragged

### DIFF
--- a/jquery.cropbox.js
+++ b/jquery.cropbox.js
@@ -54,7 +54,7 @@
           if (self.image_src === image_src)
             return;
           self.$frame.width(self.options.width).height(self.options.height);
-          self.$image.css({width: '', left: '', top: ''});
+          self.$image.css({width: '', left: 0, top: 0});
           self.image_src = image_src;
           self.width = this.width;
           self.height = this.height;


### PR DESCRIPTION
Initialize the top (and left) to 0px - otherwise top is undefined if the image isn't dragged. This causes a NaN to be passed into context.drawImage in getDataURL and results in a transparent png being returned by canvas.toDataURL().
