### PR TITLE
Use Math.ceil for cropX, cropY - exports image without transparent edges

### DIFF
--- a/jquery.cropbox.js
+++ b/jquery.cropbox.js
@@ -204,8 +204,8 @@
       },
       update: function() {
         this.result = {
-          cropX: -Math.floor(parseInt(this.$image.css('left'), 10) / this.percent),
-          cropY: -Math.floor(parseInt(this.$image.css('top'), 10) / this.percent),
+          cropX: -Math.ceil(parseInt(this.$image.css('left'), 10) / this.percent),
+          cropY: -Math.ceil(parseInt(this.$image.css('top'), 10) / this.percent),
           cropW: Math.round(this.options.width / this.percent),
           cropH: Math.round(this.options.height / this.percent),
           stretch: this.minPercent > 1


### PR DESCRIPTION
Currently, in Chrome - if you drag the image all the way top and left - in the exported image you get a 1px transparent edge at the bottom and right side of the image.

I've changed Math.floor to Math.ceil in cropX and cropY computation and that seems to fix the problem, although I'm not sure of exactly why, cause ctx.drawImage is tricky to understand ;)

Here you can see an example of exported image in a box with red background (and thick yellow border) - the red edges are transparent part of the png image.

![screen shot 2014-01-30 at 18 59 49](https://f.cloud.github.com/assets/324440/2043602/b951cbfc-89e0-11e3-9a2e-5e899cf1c326.png)

You can see the bug being reproduced here (using Chrome):
http://jsbin.com/aNIRAQOy/1/edit?output

And here is the same jsbin, but with the patched version of jquery-cropbox from this PR:
http://jsbin.com/aNIRAQOy/3/edit?output
