### PR TITLE
Expose constructor so that we can extend the plugin.

### DIFF
--- a/jquery.cropbox.js
+++ b/jquery.cropbox.js
@@ -44,6 +44,7 @@
     }
 
     Crop.prototype = {
+      constructor: Crop,
       init: function () {
         var self = this;
 
@@ -273,6 +274,8 @@
       showControls: 'auto',
       label: 'Drag to crop'
     };
+    
+    $.fn[pluginName].Constructor = Crop;
   }
 
   if (typeof require === "function" && typeof exports === "object" && typeof module === "object")


### PR DESCRIPTION
I need to modify the behavior of this plugin, but at the moment I'm unable to extend it.

This PR exposes the `Crop` constructor so we can use it.
This is similar to twitter bootstrap, see: https://github.com/twbs/bootstrap/blob/master/js/affix.js#L133
