### PR TITLE
Fix Hammerjs unbind events

### DIFF
--- a/jquery.cropbox.js
+++ b/jquery.cropbox.js
@@ -57,7 +57,6 @@
         this.updateOptions();
 
         if (typeof $.fn.hammer === 'function' || typeof Hammer !== 'undefined') {
-          this.hammerit;
 		  var dragData;
           if (typeof $.fn.hammer === 'function')
             this.hammerit = this.$image.hammer().data('hammer'); // Get the hammer instance after it has been created.

--- a/jquery.cropbox.js
+++ b/jquery.cropbox.js
@@ -57,16 +57,17 @@
         this.updateOptions();
 
         if (typeof $.fn.hammer === 'function' || typeof Hammer !== 'undefined') {
-          var hammerit, dragData;
+          this.hammerit;
+		  var dragData;
           if (typeof $.fn.hammer === 'function')
-            hammerit = this.$image.hammer().data('hammer'); // Get the hammer instance after it has been created.
+            this.hammerit = this.$image.hammer().data('hammer'); // Get the hammer instance after it has been created.
           else
-            hammerit = Hammer(this.$image.get(0));
+            this.hammerit = Hammer(this.$image.get(0));
 		  // Enable panning in all directions without any threshold.
-		  hammerit.get('pan').set({ direction: Hammer.DIRECTION_ALL, threshold: 0 });
+		  this.hammerit.get('pan').set({ direction: Hammer.DIRECTION_ALL, threshold: 0 });
 		  // Enable pinching.
-		  hammerit.get('pinch').set({ enable: true });
-          hammerit.on('panleft panright panup pandown', function(e) {
+		  this.hammerit.get('pinch').set({ enable: true });
+          this.hammerit.on('panleft panright panup pandown', function(e) {
             if (!dragData)
               dragData = {
                 startX: self.img_left,
@@ -158,13 +159,8 @@
       },
 
       remove: function () {
-        var hammerit;
-        if (typeof $.fn.hammer === 'function')
-          hammerit = this.$image.data('hammer');	// Get hammer instance object.
-        else if (typeof Hammer !== 'undefined')
-          hammerit = Hammer(this.$image.get(0));
-        if (hammerit)
-          hammerit.off('panleft panright panup pandown panend pancancel doubletap pinchin pinchout');
+        if (this.hammerit)
+          this.hammerit.off('panleft panright panup pandown panend pancancel doubletap pinchin pinchout');
         this.$frame.off('.' + pluginName);
         this.$image.off('.' + pluginName);
         this.$image.css({width: '', left: '', top: ''});


### PR DESCRIPTION
Making the hammerjs instance a property of cropbox so we can properly
unbind the events in .remove();

While creating the pause function (see other PR), i noticed that in the remove() function, doing "hammerit = Hammer(this.$image.get(0));" was actually creating a NEW instance of hammerjs on the element instead of retrieving the existing one.

After looking around, just storing the one with used to bind the events seemd to be the easiest way to do it, so this PR does just that.
